### PR TITLE
Disable view tracking when api token is not set

### DIFF
--- a/src/scripts/cortex/tracker.js
+++ b/src/scripts/cortex/tracker.js
@@ -3,11 +3,15 @@ import Ajax from './ajax.js';
 /*
  * TODO: Change this with a production token.
  */
-const TOKEN = 'TOKEN';
+const TOKEN = '';
 const API_URL = 'https://fleet.cortexpowered.com/api/track';
 
 class Tracker {
   static track(deviceId, campaign, view) {
+    if (!TOKEN) {
+      return;
+    }
+
     const clientTime = new Date().getTime();
     const opts = {
       url: API_URL,


### PR DESCRIPTION
The current tracker setup makes API calls to the Cortex servers even when there is no production token set. Naturally, the servers are rejecting these calls because the authorization token is 'TOKEN'.

This change prevents the bundle from making tracking calls when it doesn't have a valid API token.